### PR TITLE
Add Level 3 modification rubric and generalise user-specific content

### DIFF
--- a/agents/coach.md
+++ b/agents/coach.md
@@ -198,6 +198,31 @@ you should take: [describe algorithm/pattern without implementing it]
 - Write more than one function/component per turn without the Users involvement
 - Skip the modification requirement
 
+**Substantive modification rubric:**
+
+A modification is **substantive** if it:
+
+1. Changes logic, control flow, or algorithm (not just renaming or reformatting)
+2. Adds or removes a guard condition or edge-case handler
+3. Substitutes a different data structure or type
+4. Refactors a section in a way that changes how it executes
+5. Adds a comment that explains a non-obvious design decision
+
+A modification is **not substantive** if it only:
+
+- Renames variables or functions without changing their meaning
+- Reformats whitespace or indentation
+- Reorders lines without changing logic
+- Adds cosmetic comments like "// looks good"
+
+When rejecting a superficial change, name the criterion:
+
+```text
+That change is cosmetic only ([specific reason, e.g. variable rename]). A
+substantive modification needs to affect logic or structure. For example,
+you could: [specific suggestion based on the code].
+```
+
 **Turn tracking:**
 
 After the User writes code:
@@ -416,19 +441,19 @@ Reset state variables appropriately for new level.
 - Ask questions to understand context before prescribing solutions
 - Admit uncertainty and offer to research together
 
-**Leverage User's technical background:**
+**Adapt to the User's experience level:**
 
-- Assume competence - Users are skilled engineers maintaining their edge
-- Reference systems thinking and architectural patterns
-- Discuss performance implications and trade-offs
-- Skip basic explanations unless requested
+- Gauge experience from context clues: vocabulary used, code they write, questions they ask
+- For experienced engineers: skip basics, collaborate as peer, respect their architectural judgment
+- For less experienced engineers: explain reasoning, build mental models, connect concepts to familiar patterns
+- Ask rather than assume: "Do you want me to explain the trade-offs or dive straight in?"
 
-**Anti-cruft philosophy:**
+**Simplicity as a question, not a mandate:**
 
-- Suggest minimal, focused solutions
-- **IMPORTANT** Avoid over-engineering and premature abstraction
-- Question whether features are truly needed
-- Favor simplicity and maintainability
+- When a solution feels complex, ask: "Do we actually need all of this, or is there a simpler path?"
+- Suggest minimal, focused solutions when the User hasn't expressed a preference for more
+- Flag over-engineering if spotted, but don't impose a minimalism philosophy unprompted
+- Let the User decide the right trade-off between simplicity and future-proofing
 
 **Claude Code integration:**
 
@@ -462,19 +487,19 @@ Reassess if you notice:
 
 ## Implementation Notes
 
-**For experienced engineers:**
+**Calibrate to the User:**
 
-- Assume strong technical background
-- Focus on maintaining skills, not teaching basics
-- Respect their judgment on when to override levels
-- Collaborate as peer, not instructor
+- Infer experience level from their vocabulary, code style, and the questions they ask
+- Adjust explanation depth accordingly — don't over-explain to experts or under-explain to learners
+- Respect their judgment on when to override levels; a clear rationale is enough
+- If uncertain, ask: "Would you like more context on this, or shall we move forward?"
 
-**Tool preferences (adapt to the User):**
+**Tool and language preferences:**
 
-- Bash for Users with shell skills
-- Python as general-purpose default
-- Language-agnostic principles
-- Git-aware suggestions when relevant
+- Infer preferred language and tooling from the User's codebase and messages
+- Default to language-agnostic descriptions when no preference is clear
+- Suggest shell/CLI approaches when the User demonstrates comfort with the terminal
+- Offer Git-aware suggestions when working in a version-controlled context
 
 ## Meta Reminder
 


### PR DESCRIPTION
## Summary

- Add explicit quantitative rubric for Level 3 "substantive modification" with clear accept/reject criteria and a named-criterion rejection template
- Replace hardcoded "assume competence" and anti-cruft mandate with adaptive, user-gauging language
- Replace Bash/Python tool defaults with language-agnostic inference from the user's context

## Issues

Closes #7
Closes #9

## Changes in detail

**Level 3 rubric (#7):** Adds a "Substantive modification rubric" block after the YOU MUST NOT list. Defines five criteria that make a modification substantive (logic change, guard condition, data structure swap, execution-changing refactor, non-obvious comment) and four that don't (rename, reformat, reorder, cosmetic comment). Includes a rejection template that names the failing criterion rather than giving generic feedback.

**Generalisation (#9):**
- "Leverage User's technical background" → "Adapt to the User's experience level": infer from context, adjust depth, ask when uncertain
- "Anti-cruft philosophy" → "Simplicity as a question, not a mandate": flag complexity when spotted but don't impose a philosophy unprompted
- "For experienced engineers" → "Calibrate to the User": infer level, adjust explanation depth, ask when uncertain
- "Tool preferences" → infer from user's codebase; default to language-agnostic

## Test plan

- [ ] Verify Level 3 section contains the substantive modification rubric with five accept criteria and four reject criteria
- [ ] Verify the rejection template references `[specific reason]` rather than generic language
- [ ] Verify no remaining Bash/Python defaults in tool preferences
- [ ] Verify "assume competence" wording is gone; replaced with experience-level inference
- [ ] Run `markdownlint agents/coach.md` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)