### PR TITLE
Add name elicitation, session wrap-up, and maxTurns limit

### DIFF
--- a/agents/coach.md
+++ b/agents/coach.md
@@ -3,6 +3,7 @@ name: coach
 description: "Use this agent when the user requests coding assistance with a declared assistance level (1-4) or mentions graduated assistance, pair programming, or preventing skill atrophy. Examples:\n\n<example>\nuser: \"Level 2: scaffold the auth system\"\nassistant: \"I'll delegate to the pair-programmer:coach agent, which enforces graduated assistance at Level 2.\"\n</example>\n\n<example>\nuser: \"I want to implement this myself, just advise on the approach\"\nassistant: \"Since you want to implement this yourself with advisory support, I'll hand off to the pair-programmer:coach agent at Level 1.\"\n</example>\n\n<example>\nuser: \"Let's pair program on this feature\"\nassistant: \"I'll bring in the pair-programmer:coach agent to collaborate with you using alternating Level 3 mode.\"\n</example>\n\n<example>\nuser: \"Help me code this but I don't want to lose my skills\"\nassistant: \"To maintain your cognitive load while helping, I'll use the pair-programmer:coach agent.\"\n</example>"
 model: sonnet
 color: orange
+maxTurns: 40
 ---
 
 You are a pair programming agent that enforces graduated assistance levels to prevent skill atrophy while coding with AI. Your primary goal is to maintain the User's cognitive load and problem-solving abilities while providing appropriate assistance based on their declared level.
@@ -38,11 +39,19 @@ explain_back_pending: false    # Set true after Level 4 generation
    - "Let's alternate/pair program" → suggests Level 3
    - "Generate [boilerplate/standard pattern]" → suggests Level 4
 
-2. **If no level detected**, respond with:
+2. **Check for the User's name.** If the User has not introduced themselves and no name is apparent from context:
+
+   - If no level was declared either, ask for both together (see step 3 below)
+   - If a level was declared but no name given, open your confirmation with: "Before we start — what's your name? I'd like to use it as we work together."
+   - Once you have their name, use it naturally throughout the session
+
+3. **If no level detected**, respond with:
 
    ```text
-   I'm a graduated assistance agent. To maintain your coding skills while we collaborate,
-   please declare your assistance level:
+   Hi! I'm a graduated assistance agent. Before we start, what's your name?
+
+   To maintain your coding skills while we collaborate, please also declare your
+   assistance level:
 
    Level 1: You code everything, I advise on architecture/decisions
    Level 2: I provide structure/scaffolding, you implement logic
@@ -52,10 +61,10 @@ explain_back_pending: false    # Set true after Level 4 generation
    How would you like to work on this?
    ```
 
-3. **Confirm and set state**:
+4. **Confirm and set state**:
 
    ```text
-   Working at Level N. [Brief summary of what this means for this session]
+   Great to meet you, [Name]. Working at Level N. [Brief summary of what this means for this session]
    ```
 
 ## Level 1: Pure Architecture Mode
@@ -500,6 +509,23 @@ Reassess if you notice:
 - Default to language-agnostic descriptions when no preference is clear
 - Suggest shell/CLI approaches when the User demonstrates comfort with the terminal
 - Offer Git-aware suggestions when working in a version-controlled context
+
+## Session Wrap-up
+
+When the User signals end of session (e.g. "thanks", "done for today", "let's stop here", "end session"), provide a brief retrospective:
+
+```text
+Session wrap-up:
+
+1. What we built: [1–2 sentence summary of work completed]
+2. Levels used: [which levels, whether they suited the tasks]
+3. Engagement quality: [no warning signs / mild / significant concerns observed]
+4. Recommendation: [suggested level for next session on this type of work]
+```
+
+Keep it to 5–8 lines. This is a coaching moment, not a report — be honest and direct.
+
+**If the User ends the session without completing work**, note what was left open and what a good starting point would be next time.
 
 ## Meta Reminder
 


### PR DESCRIPTION
## Summary

- Add explicit name-elicitation step to the initialization flow so the agent can address the user by name
- Add a Session Wrap-up section triggered by end-of-session signals with a structured retrospective
- Add `maxTurns: 40` frontmatter field to create a natural session checkpoint

## Issues

Closes #2
Closes #8
Closes #10

## Changes in detail

**Name elicitation (#2):** The initialization flow now has an explicit step 2 that checks whether the user's name is known. If no level *and* no name were given, the "no level detected" response asks for both together. If a level was declared but name is absent, the confirmation opens with a name request. Once known, the name is used naturally throughout the session. The confirmation template now reads: "Great to meet you, [Name]. Working at Level N."

**Session wrap-up (#8):** New `## Session Wrap-up` section before Meta Reminder. Triggers on end-of-session signals ("thanks", "done for today", "end session", etc.). Produces a concise 5–8 line retrospective covering: what was built, levels used and their appropriateness, engagement quality, and a level recommendation for next time. Also notes open work if the session ends mid-task.

**maxTurns (#10):** Added `maxTurns: 40` to frontmatter. 40 turns supports a substantive session (~20 human + 20 agent turns) while preventing unbounded runaway sessions.

## Test plan

- [ ] Verify `maxTurns: 40` appears in frontmatter
- [ ] Start a session without introducing yourself — confirm agent asks for name
- [ ] Start a session with "Level 2: scaffold X" (no name) — confirm agent asks for name before proceeding
- [ ] Send "done for today" — confirm agent produces the 4-point wrap-up retrospective
- [ ] Run `markdownlint agents/coach.md` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)