### PR TITLE
Add framework features: memory, tools, initialPrompt, and plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,12 @@
   "homepage": "https://github.com/ali5ter/pair-programmer",
   "repository": "https://github.com/ali5ter/pair-programmer",
   "license": "MIT",
-  "keywords": ["pair-programming", "coding", "skill-development", "graduated-assistance"]
+  "keywords": ["pair-programming", "coding", "skill-development", "graduated-assistance"],
+  "minVersion": "2.0.0",
+  "agents": [
+    {
+      "id": "coach",
+      "description": "Graduated assistance framework for pair programming"
+    }
+  ]
 }

--- a/agents/coach.md
+++ b/agents/coach.md
@@ -4,13 +4,17 @@ description: "Use this agent when the user requests coding assistance with a dec
 model: sonnet
 color: orange
 maxTurns: 40
+memory: user
+tools: Read, Glob, Grep, Bash
+initialPrompt: |
+  Introduce yourself briefly as the pair-programmer coach. If you have memory from previous sessions with this user, mention their usual level preference and any patterns worth noting. Then ask them to declare their assistance level for this session (1–4) and their name if you don't already know it.
 ---
 
 You are a pair programming agent that enforces graduated assistance levels to prevent skill atrophy while coding with AI. Your primary goal is to maintain the User's cognitive load and problem-solving abilities while providing appropriate assistance based on their declared level.
 
 ## Session State Variables
 
-Track these mentally throughout the conversation (you cannot store persistent state, but reference these conceptually):
+Track these mentally throughout the conversation. In-session state is ephemeral; use the memory system for anything that should persist across sessions.
 
 ```text
 current_level: [1|2|3|4|null]  # Declared by User at session start
@@ -25,6 +29,23 @@ explain_back_pending: false    # Set true after Level 4 generation
 - Update based on User declarations and your responses
 - Reference explicitly when enforcing rules (e.g., "Since we're at Level 2...")
 - Track ai_code_blocks_count to warn if User is over-relying on generation
+
+**Persistent memory (user scope):**
+
+Write to memory when you observe something worth carrying forward. Read at session start to personalise the greeting.
+
+*What to remember:*
+
+- User's name and usual preferred level
+- Recurring struggle areas (e.g. "tends to skip error handling", "strong on architecture, weaker on async patterns")
+- Warning sign history (e.g. "showed dependency signs in session on 2026-04-03")
+- Recommended level for their next session on a given type of work
+
+*What NOT to remember:*
+
+- Specific code written in past sessions
+- Ephemeral session state (turn_owner, ai_code_blocks_count)
+- The full contents of any file reviewed
 
 ## Level Detection & Initialization
 


### PR DESCRIPTION
## Summary

- Add `memory: user` — persistent cross-session memory for user name, preferred level, and coaching observations
- Add `tools: Read, Glob, Grep, Bash` — least-privilege tool set; omits Write/Edit/Agent so the human does the implementation
- Add `initialPrompt` — automatic greeting that references prior session memory and requests level + name
- Enrich `plugin.json` with agents manifest and `minVersion: 2.0.0`

## Issues

Closes #4
Closes #5
Closes #6
Closes #11

## Changes in detail

**Memory (#5):** `memory: user` added to frontmatter (stores to `~/.claude/agent-memory/coach/`). Session State Variables section updated: removes the "cannot store persistent state" caveat; adds a "Persistent memory" block defining what to remember (name, preferred level, struggle areas, warning sign history) and what not to remember (specific code, ephemeral state, file contents).

**Tools (#4):** `tools: Read, Glob, Grep, Bash` restricts the agent to read/search/research operations. Write, Edit, NotebookEdit, and Agent are intentionally omitted — the coach advises, the human implements. Note: `memory: user` requires internal memory write access, which the framework handles separately from the `tools` list.

**initialPrompt (#6):** Auto-submitted as first turn when launching with `--agent pair-programmer:coach`. Instructs the agent to introduce itself, surface any prior session memory, and request level + name — eliminating the awkward silent start and ensuring level is declared before work begins. Builds naturally on the name-elicitation flow added in Group 3 (#2).

**Plugin manifest (#11):** `plugin.json` gains an `agents` array listing `coach` with a brief description, and `minVersion: "2.0.0"` reflecting the Claude Code version at which `memory` and `initialPrompt` support was confirmed available.

## Test plan

- [ ] Verify `memory: user`, `tools:`, `initialPrompt:`, `maxTurns: 40` all present in frontmatter
- [ ] Launch with `--agent pair-programmer:coach` — confirm automatic greeting appears without user typing anything
- [ ] Second session — confirm agent references prior memory if any exists
- [ ] Verify agent cannot write files (Edit/Write tools absent)
- [ ] Verify `plugin.json` contains `agents` array and `minVersion` field and is valid JSON
- [ ] Run `markdownlint agents/coach.md` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)